### PR TITLE
Apply on-off biz logic of osc to midi

### DIFF
--- a/app/js/models/instrument.coffee
+++ b/app/js/models/instrument.coffee
@@ -30,7 +30,8 @@ Seq25.Instrument = Ember.Object.extend
     unless @get 'isMuted'
       (@get('oscillators')[pitch.number] ||= Seq25.Osc.create(Ember.merge(pitch: pitch, @getProperties('context', 'output', 'shape'))))
         .play(secondsFromNow, duration)
-    Seq25.midi.sendOnAt(pitch.name, secondsFromNow)
+      Seq25.midi.sendOnAt(pitch.name, secondsFromNow)
+      Seq25.midi.sendOffAt(pitch.name, secondsFromNow + duration) if duration
 
   stop: (pitch, secondsFromNow=0)->
     @get('oscillators')[pitch.number]?.stop(secondsFromNow)


### PR DESCRIPTION
There's an abstraction needed here somewhere, but I'm not sure what it is.  An oscillator and midi share the same on off logic, but not pitches.  Midi seems like its its own instrument, but it'd be nice to have multiple instruments getting the on-off signals.  The abstraction will show itself in time I guess.
