### PR TITLE
Scroll to note position

### DIFF
--- a/app/js/views/notes.coffee
+++ b/app/js/views/notes.coffee
@@ -7,7 +7,11 @@ Seq25.NoteView = Ember.View.extend
   attributeBindings: ['style', 'class']
 
   didInsertElement: ->
-    @scrollNote()
+    @scrollNote() unless @noteOnScreen()
+
+  noteOnScreen: ->
+    $(this.element).offset().top > document.documentElement.scrollTop and
+      $(this.element).offset().top  < (document.documentElement.scrollTop + screen.height)
 
   totalTicks: Em.computed.alias 'content.part.totalTicks'
 


### PR DESCRIPTION
A note should not be allowed to be moved or created offscreen.  Moved notes will cause a screen scroll to accommodate the note's new position.  Created notes will cause a screen scroll to accommodate the note's new position, but only if they've been created offscreen.  Creating notes by clicking will not scroll because they are on screen.  Pressing key `c` will cause a scroll if the top of the piano roll is not on the screen.

I found this hard to test.  In the context of the test I don't have access to the document or the window with which to get `document.documentElement.scrollTop` by which I'd be able to determine if the window had scrolled. 
