### PR TITLE
Prevent misfires on consecutive abutting notes

### DIFF
--- a/app/js/models/osc.coffee
+++ b/app/js/models/osc.coffee
@@ -43,5 +43,5 @@ Seq25.Osc = Ember.Object.extend
 
   stop: (secondsFromNow=0)->
     {context, release} = @getProperties 'context', 'release'
-    contextTime = context.currentTime + secondsFromNow
+    contextTime = context.currentTime + (secondsFromNow - 0.003)
     @gain.linearRampToValueAtTime(0, contextTime + release)


### PR DESCRIPTION
See http://seq25.com/#/r/64 to experience the issue.

On note sequences where the end of the first note is the same time as
the start of the second note, the order in which noteA.end and
noteB.start occur is indeterminate, causing audible misfires.
Removing thousandthds of a second from the end of noteA, allows
the application to know that noteA.end should occur before noteB.start

0.003 was the lowest 1000th of a second value that did not allow any misfires over 30 to 40 beats.
Subtracting 0.002 from the end allowed 8 misfires over 30 to 40 beats.
Subtracting 0.001 allowed many misfires.
