### PR TITLE
Calculate scroll 'onScreen' window.innerHeight

### DIFF
--- a/app/js/views/notes-edit.coffee
+++ b/app/js/views/notes-edit.coffee
@@ -40,7 +40,7 @@ Seq25.NoteEditView = Seq25.NoteView.extend
   noteOnScreen: ->
     top = @$().offset().top
     top > document.documentElement.scrollTop and
-    top < (document.documentElement.scrollTop + screen.height)
+    top < (document.documentElement.scrollTop + window.innerHeight)
 
   scrollNote: (->
     Ember.run.scheduleOnce 'afterRender', this, ->


### PR DESCRIPTION
Error:  A note can scroll off the bottom of the screen by 4 pitches.

Fix:  Change screen.height to window.innerHeight allows screen to scroll when a note goes off the bottom of the screen.
